### PR TITLE
Made displayName optional in request for register

### DIFF
--- a/packages/server/src/modules/user/user.controller.js
+++ b/packages/server/src/modules/user/user.controller.js
@@ -6,7 +6,7 @@ const SALT_ROUNDS = 10;
 // Creates a new user. Checks if username is unique, hashes passwrd,
 // and creates user in db.
 export async function handleCreateUser(req, reply) {
-  let { username } = req.body;
+  let { username, displayName } = req.body;
   const { password } = req.body;
   // Validate data
   username = username.toLowerCase();
@@ -21,13 +21,15 @@ export async function handleCreateUser(req, reply) {
       message: 'User already exists with this username',
     });
   }
+  // If no display name, set to username
+  if (!displayName) displayName = username;
   // Hashes password and creates user in db
   try {
     const hash = await bcrypt.hash(password, SALT_ROUNDS);
     const user = await prisma.user.create({
       data: {
         username,
-        displayName: username,
+        displayName,
         password: hash,
         role: 'BASIC',
       },

--- a/packages/server/src/modules/user/user.schema.js
+++ b/packages/server/src/modules/user/user.schema.js
@@ -6,6 +6,11 @@ import { buildJsonSchemas } from 'fastify-zod';
 // Register: Register data, response schema
 const createUserSchema = z.object({
   username: z.string().min(3).max(24),
+  displayName: z.string()
+    .min(3)
+    .max(24)
+    .optional()
+    .or(z.literal('')),
   password: z.string().min(6).max(24),
 });
 
@@ -17,7 +22,7 @@ const createUserResponseSchema = z.object({
 // Update user schema
 const updateUserSchema = z.object({
   username: z.string().min(3).max(24),
-  password: z.string().min(6),
+  password: z.string().min(6).max(24),
   displayName: z.string().min(3).max(24),
   role: z.string(),
 });


### PR DESCRIPTION
If displayName is in body for register user request, displayName is now saved instead of being overwritten by username. Fixes #73.